### PR TITLE
Add name lookup and Swagger doc endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,15 @@ It uses the [imdbinfo](https://github.com/tveronesi/imdbinfo) package to fetch m
     ```
    
 3. The API will be available at `http://127.0.0.1:5000`.
-4. The api only has 2 endpoints:
-   - `/search?q=<searchstring>` 
+4. The API exposes the following endpoints:
+   - `/search?q=<searchstring>`
      - example: http://127.0.0.1:5000/search?q=matrix
-   - `/movie/<imdb_id>`: 
+   - `/movie/<imdb_id>`
      - example: http://127.0.0.1:5000/movie/0234215
+   - `/name/<imdb_id>`
+     - example: http://127.0.0.1:5000/name/nm0000206
+   - `/apidoc`
+     - returns a Swagger/OpenAPI description of the service
 
 
 ## Running Locally without Docker

--- a/api.py
+++ b/api.py
@@ -1,6 +1,6 @@
 # python
 from flask import Flask, jsonify, request
-from imdbinfo.services import search_title, get_movie
+from imdbinfo.services import search_title, get_movie, get_name
 
 app = Flask(__name__)
 
@@ -21,6 +21,16 @@ def get_imdb_data(imdb_id):
         return jsonify({"error": "Movie not found"}), 404
 
     return jsonify(movie_data.model_dump())
+
+
+@app.route("/name/<string:imdb_id>")
+def get_name_data(imdb_id):
+    """Retrieve name details by IMDB ID."""
+    name_data = get_name(imdb_id)
+    if not name_data:
+        return jsonify({"error": "Name not found"}), 404
+
+    return jsonify(name_data.model_dump())
 
 @app.route("/search")
 def search_imdb():
@@ -43,6 +53,70 @@ def search_imdb():
         return jsonify({"error": "No results found"}), 404
 
     return jsonify(results.model_dump())
+
+
+@app.route("/apidoc")
+def apidoc():
+    """Return a minimal OpenAPI specification for the service."""
+    spec = {
+        "openapi": "3.0.0",
+        "info": {"title": "qd_imdb_api", "version": "1.0.0"},
+        "paths": {
+            "/movie/{imdb_id}": {
+                "get": {
+                    "summary": "Retrieve movie details by IMDB ID",
+                    "parameters": [
+                        {
+                            "in": "path",
+                            "name": "imdb_id",
+                            "schema": {"type": "string"},
+                            "required": True,
+                        }
+                    ],
+                    "responses": {
+                        "200": {"description": "Movie details"},
+                        "404": {"description": "Movie not found"},
+                    },
+                }
+            },
+            "/search": {
+                "get": {
+                    "summary": "Search for movie titles by a query term",
+                    "parameters": [
+                        {
+                            "in": "query",
+                            "name": "q",
+                            "schema": {"type": "string"},
+                            "required": True,
+                        }
+                    ],
+                    "responses": {
+                        "200": {"description": "Search results"},
+                        "400": {"description": "Missing query"},
+                        "404": {"description": "No results found"},
+                    },
+                }
+            },
+            "/name/{imdb_id}": {
+                "get": {
+                    "summary": "Retrieve name details by IMDB ID",
+                    "parameters": [
+                        {
+                            "in": "path",
+                            "name": "imdb_id",
+                            "schema": {"type": "string"},
+                            "required": True,
+                        }
+                    ],
+                    "responses": {
+                        "200": {"description": "Name details"},
+                        "404": {"description": "Name not found"},
+                    },
+                }
+            },
+        },
+    }
+    return jsonify(spec)
 
 if __name__ == "__main__":
     app.run(debug=True, host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- add `/name/<imdb_id>` endpoint that fetches person details using `imdbinfo`'s `get_name`
- expose `/apidoc` providing a minimal Swagger/OpenAPI spec for all endpoints
- document new routes in README

## Testing
- `python -m py_compile api.py`
- `python api.py` *(fails: ImportError: cannot import name 'get_name' from 'imdbinfo.services')*
- `pip install --upgrade imdbinfo` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688bca334b2083249a02c778f417a5b8