### PR TITLE
Integrate Flask-RESTX for automatic API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It uses the [imdbinfo](https://github.com/tveronesi/imdbinfo) package to fetch m
    - `/name/<imdb_id>`
      - example: http://127.0.0.1:5000/name/nm0000206
    - `/apidoc`
-     - returns a Swagger/OpenAPI description of the service
+     - auto-generated Swagger/OpenAPI documentation for the service
 
 
 ## Running Locally without Docker
@@ -44,6 +44,7 @@ If you prefer to run the application without Docker, you can do so by following 
 - Python 3.8 or higher
 - `imdbinfo` package for fetching movie details
 - Flask for creating the API service
+- Flask-RESTX for REST utilities and automatic API documentation
 
 ## Package imdbinfo
 

--- a/api.py
+++ b/api.py
@@ -1,122 +1,49 @@
 # python
-from flask import Flask, jsonify, request
-from imdbinfo.services import search_title, get_movie, get_name
+from flask import Flask, request
+from flask_restx import Api, Resource
+from imdbinfo.services import get_movie, get_name, search_title
 
 app = Flask(__name__)
-
-@app.route("/movie/<string:imdb_id>")
-def get_imdb_data(imdb_id):
-    """
-    Retrieve movie details by IMDB ID.
-
-    Args:
-        imdb_id (str): The IMDB ID of the movie.
-
-    Returns:
-        Response: JSON object with movie details if found,
-                  otherwise an error message with HTTP 404.
-    """
-    movie_data = get_movie(imdb_id)
-    if not movie_data:
-        return jsonify({"error": "Movie not found"}), 404
-
-    return jsonify(movie_data.model_dump())
+api = Api(app, version="1.0.0", title="qd_imdb_api", doc="/apidoc")
 
 
-@app.route("/name/<string:imdb_id>")
-def get_name_data(imdb_id):
-    """Retrieve name details by IMDB ID."""
-    name_data = get_name(imdb_id)
-    if not name_data:
-        return jsonify({"error": "Name not found"}), 404
-
-    return jsonify(name_data.model_dump())
-
-@app.route("/search")
-def search_imdb():
-    """
-    Search for movie titles by a query term.
-
-    Query Parameters:
-        q (str): The search term for the movie title.
-
-    Returns:
-        Response: JSON object with search results if found,
-                  otherwise an error message with HTTP 400 or 404.
-    """
-    query = request.args.get("q")
-    if not query:
-        return jsonify({"error": "Query parameter is required"}), 400
-
-    results = search_title(query)
-    if not results:
-        return jsonify({"error": "No results found"}), 404
-
-    return jsonify(results.model_dump())
+@api.route("/movie/<string:imdb_id>")
+@api.param("imdb_id", "The IMDB ID of the movie")
+class MovieResource(Resource):
+    def get(self, imdb_id: str):
+        """Retrieve movie details by IMDB ID."""
+        movie_data = get_movie(imdb_id)
+        if not movie_data:
+            api.abort(404, "Movie not found")
+        return movie_data.model_dump()
 
 
-@app.route("/apidoc")
-def apidoc():
-    """Return a minimal OpenAPI specification for the service."""
-    spec = {
-        "openapi": "3.0.0",
-        "info": {"title": "qd_imdb_api", "version": "1.0.0"},
-        "paths": {
-            "/movie/{imdb_id}": {
-                "get": {
-                    "summary": "Retrieve movie details by IMDB ID",
-                    "parameters": [
-                        {
-                            "in": "path",
-                            "name": "imdb_id",
-                            "schema": {"type": "string"},
-                            "required": True,
-                        }
-                    ],
-                    "responses": {
-                        "200": {"description": "Movie details"},
-                        "404": {"description": "Movie not found"},
-                    },
-                }
-            },
-            "/search": {
-                "get": {
-                    "summary": "Search for movie titles by a query term",
-                    "parameters": [
-                        {
-                            "in": "query",
-                            "name": "q",
-                            "schema": {"type": "string"},
-                            "required": True,
-                        }
-                    ],
-                    "responses": {
-                        "200": {"description": "Search results"},
-                        "400": {"description": "Missing query"},
-                        "404": {"description": "No results found"},
-                    },
-                }
-            },
-            "/name/{imdb_id}": {
-                "get": {
-                    "summary": "Retrieve name details by IMDB ID",
-                    "parameters": [
-                        {
-                            "in": "path",
-                            "name": "imdb_id",
-                            "schema": {"type": "string"},
-                            "required": True,
-                        }
-                    ],
-                    "responses": {
-                        "200": {"description": "Name details"},
-                        "404": {"description": "Name not found"},
-                    },
-                }
-            },
-        },
-    }
-    return jsonify(spec)
+@api.route("/name/<string:imdb_id>")
+@api.param("imdb_id", "The IMDB ID of the name entry")
+class NameResource(Resource):
+    def get(self, imdb_id: str):
+        """Retrieve name details by IMDB ID."""
+        name_data = get_name(imdb_id)
+        if not name_data:
+            api.abort(404, "Name not found")
+        return name_data.model_dump()
+
+
+@api.route("/search")
+class SearchResource(Resource):
+    @api.doc(params={"q": "The search term for the movie title"})
+    def get(self):
+        """Search for movie titles by a query term."""
+        query = request.args.get("q")
+        if not query:
+            api.abort(400, "Query parameter is required")
+
+        results = search_title(query)
+        if not results:
+            api.abort(404, "No results found")
+
+        return results.model_dump()
+
 
 if __name__ == "__main__":
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    app.run(debug=True, host="0.0.0.0", port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 imdbinfo==0.3.0
 Flask==3.0.3
+flask-restx==1.3.0


### PR DESCRIPTION
## Summary
- use Flask-RESTX to expose REST resources and generate Swagger docs at `/apidoc`
- document API docs in README and pin flask-restx dependency

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement flask-restx==1.3.0)*
- `python -m py_compile api.py`
- `python api.py` *(fails: ModuleNotFoundError: No module named 'flask_restx')*

------
https://chatgpt.com/codex/tasks/task_e_688bcc2102808324919860ed3e5d5c68